### PR TITLE
Feature/todo 할일 단일 조회기능추가, 예외처리를 위한 ErrorCode, CustomException 추가

### DIFF
--- a/src/main/java/com/example/todo/domain/global/common/CommonResponse.java
+++ b/src/main/java/com/example/todo/domain/global/common/CommonResponse.java
@@ -1,0 +1,18 @@
+package com.example.todo.domain.global.common;
+
+import com.example.todo.domain.todo.dto.TodoCreationResponseDto;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CommonResponse<T> {
+
+    private final String message;
+
+    private final T payload;
+
+    public static <T> CommonResponse<T> of(String message, T payload) {
+        return new CommonResponse<>(message, payload);
+    }
+}

--- a/src/main/java/com/example/todo/domain/global/common/CommonResponse.java
+++ b/src/main/java/com/example/todo/domain/global/common/CommonResponse.java
@@ -1,6 +1,5 @@
 package com.example.todo.domain.global.common;
 
-import com.example.todo.domain.todo.dto.TodoCreationResponseDto;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 

--- a/src/main/java/com/example/todo/domain/global/exception/CustomException.java
+++ b/src/main/java/com/example/todo/domain/global/exception/CustomException.java
@@ -1,0 +1,15 @@
+package com.example.todo.domain.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class CustomException extends RuntimeException {
+
+    private final int statusCode;
+
+    public  CustomException(ErrorCode errorcode) {
+        super(errorcode.getMessage());
+        this.statusCode = errorcode.getStatusCode();
+    }
+
+}

--- a/src/main/java/com/example/todo/domain/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/todo/domain/global/exception/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.example.todo.domain.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+    // Todo
+
+    TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다.");
+
+    private final int statusCode;
+
+    private final String message;
+
+    ErrorCode(int statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/example/todo/domain/global/exception/ErrorResponse.java
+++ b/src/main/java/com/example/todo/domain/global/exception/ErrorResponse.java
@@ -1,0 +1,19 @@
+package com.example.todo.domain.global.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ErrorResponse {
+
+    private String message;
+
+    public static ErrorResponse of(String message) {
+
+        return ErrorResponse.builder()
+                .message(message)
+                .build();
+    }
+
+}

--- a/src/main/java/com/example/todo/domain/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/todo/domain/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,25 @@
+package com.example.todo.domain.global.exception;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    protected ResponseEntity<ErrorResponse> handlerCustomException(CustomException customException) {
+
+        log.error(customException.getMessage());
+
+        HttpStatus httpStatus = HttpStatus.valueOf(customException.getStatusCode());
+        ErrorResponse errorResponse = ErrorResponse.of(customException.getMessage());
+
+        return ResponseEntity.status(httpStatus).body(errorResponse);
+    }
+}

--- a/src/main/java/com/example/todo/domain/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/todo/domain/global/exception/GlobalExceptionHandler.java
@@ -3,9 +3,7 @@ package com.example.todo.domain.global.exception;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
-import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 @Slf4j

--- a/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
@@ -9,6 +9,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -37,6 +38,17 @@ public class TodoController {
 
     @GetMapping("/today")
     public List<Todo> getTodos() {
+
         return todoService.getAllTodos();
+    }
+
+    @GetMapping("/today/{id}")
+    public ResponseEntity<TodoCreationResponseDto> getTodoById(
+            @PathVariable Long id) {
+
+        TodoCreationResponseDto responseDto = todoService.getTodo(id);
+
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(responseDto);
     }
 }

--- a/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
@@ -1,5 +1,6 @@
 package com.example.todo.domain.todo.controller;
 
+import com.example.todo.domain.global.common.CommonResponse;
 import com.example.todo.domain.todo.dto.TodoCreationRequestDto;
 import com.example.todo.domain.todo.dto.TodoCreationResponseDto;
 import com.example.todo.domain.todo.entity.Todo;
@@ -43,12 +44,11 @@ public class TodoController {
     }
 
     @GetMapping("/today/{id}")
-    public ResponseEntity<TodoCreationResponseDto> getTodoById(
+    public ResponseEntity<CommonResponse<TodoCreationResponseDto>> getTodoById(
             @PathVariable Long id) {
 
         TodoCreationResponseDto responseDto = todoService.getTodo(id);
 
-        return ResponseEntity.status(HttpStatus.OK)
-                .body(responseDto);
+        return ResponseEntity.ok(CommonResponse.of("할일 단일 조회 성공", responseDto));
     }
 }

--- a/src/main/java/com/example/todo/domain/todo/service/TodoService.java
+++ b/src/main/java/com/example/todo/domain/todo/service/TodoService.java
@@ -32,9 +32,23 @@ public class TodoService {
         );
     }
 
+    @Transactional
     public List<Todo> getAllTodos() {
 
         return todoRepository.findAll();
     }
 
+    @Transactional
+    public TodoCreationResponseDto getTodo(Long id) {
+
+        Todo todo = todoRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("Todo not found"));
+
+        return new TodoCreationResponseDto(
+                todo.getId(),
+                todo.getDescription(),
+                todo.isCompleted(),
+                todo.getCreatedAt()
+        );
+    }
 }

--- a/src/main/java/com/example/todo/domain/todo/service/TodoService.java
+++ b/src/main/java/com/example/todo/domain/todo/service/TodoService.java
@@ -1,5 +1,7 @@
 package com.example.todo.domain.todo.service;
 
+import com.example.todo.domain.global.exception.CustomException;
+import com.example.todo.domain.global.exception.ErrorCode;
 import com.example.todo.domain.todo.dto.TodoCreationRequestDto;
 import com.example.todo.domain.todo.dto.TodoCreationResponseDto;
 import com.example.todo.domain.todo.entity.Todo;
@@ -42,7 +44,7 @@ public class TodoService {
     public TodoCreationResponseDto getTodo(Long id) {
 
         Todo todo = todoRepository.findById(id)
-                .orElseThrow(() -> new RuntimeException("Todo not found"));
+                .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
 
         return new TodoCreationResponseDto(
                 todo.getId(),


### PR DESCRIPTION
### 설명
이 PR은 사용자가 생성한 할일들 중에서 원하는 할일 1개를 조회하는 기능구현 이며, 예외 발생시 에대한  에러 코드와 메시지 반환하기 위해서 관련된 설정 또한 추가 하였습니다.

### 주요 변경 사항
- **Controller**: API 추가
- **Service**: 단일 조회 메서드 추가
- **예외 처리**: TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다.")
- **예외 발생시 에러코드, 메시지 반환을 위한 설정 추가** : GlobalExceptionHandler, CustomException, ErrorCdoe, ErrorResponse, CommonResponse 설정 추가

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 실행시 이전에 작성했던 할일중 찾고자 하는 할일이 조회되는것을 확인하였습니다.