### PR TITLE
Feature/todo 할일 내용 수정 기능 추가

### DIFF
--- a/src/main/java/com/example/todo/domain/global/exception/ErrorCode.java
+++ b/src/main/java/com/example/todo/domain/global/exception/ErrorCode.java
@@ -7,7 +7,8 @@ public enum ErrorCode {
 
     // Todo
 
-    TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다.");
+    TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다."),
+    TODO_DESCRIPTION_REQUIRED(400, "작성된 내용이 없습니다.");
 
     private final int statusCode;
 

--- a/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
@@ -3,6 +3,8 @@ package com.example.todo.domain.todo.controller;
 import com.example.todo.domain.global.common.CommonResponse;
 import com.example.todo.domain.todo.dto.TodoCreationRequestDto;
 import com.example.todo.domain.todo.dto.TodoCreationResponseDto;
+import com.example.todo.domain.todo.dto.TodoUpdateRequestDto;
+import com.example.todo.domain.todo.dto.TodoUpdateResponseDto;
 import com.example.todo.domain.todo.entity.Todo;
 import com.example.todo.domain.todo.service.TodoService;
 import java.util.List;
@@ -12,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -50,5 +53,15 @@ public class TodoController {
         TodoCreationResponseDto responseDto = todoService.getTodo(id);
 
         return ResponseEntity.ok(CommonResponse.of("할일 단일 조회 성공", responseDto));
+    }
+
+    @PutMapping("/today/{id}")
+    public ResponseEntity<CommonResponse<TodoUpdateResponseDto>> updateTodo(
+            @PathVariable Long id,
+            @RequestBody TodoUpdateRequestDto todoRequest) {
+
+        TodoUpdateResponseDto updatedTodo = todoService.updateTodo(id, todoRequest);
+
+        return ResponseEntity.ok().body(CommonResponse.of("할일 수정 성공", updatedTodo));
     }
 }

--- a/src/main/java/com/example/todo/domain/todo/dto/TodoUpdateRequestDto.java
+++ b/src/main/java/com/example/todo/domain/todo/dto/TodoUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.example.todo.domain.todo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class TodoUpdateRequestDto {
+
+    private String description;
+
+}

--- a/src/main/java/com/example/todo/domain/todo/dto/TodoUpdateResponseDto.java
+++ b/src/main/java/com/example/todo/domain/todo/dto/TodoUpdateResponseDto.java
@@ -1,0 +1,21 @@
+package com.example.todo.domain.todo.dto;
+
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class TodoUpdateResponseDto {
+
+    private Long id;
+
+    private String description;
+
+    private boolean completed;
+
+    private LocalDateTime createdAt;
+
+}

--- a/src/main/java/com/example/todo/domain/todo/entity/Todo.java
+++ b/src/main/java/com/example/todo/domain/todo/entity/Todo.java
@@ -10,9 +10,11 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/com/example/todo/domain/todo/service/TodoService.java
+++ b/src/main/java/com/example/todo/domain/todo/service/TodoService.java
@@ -4,6 +4,8 @@ import com.example.todo.domain.global.exception.CustomException;
 import com.example.todo.domain.global.exception.ErrorCode;
 import com.example.todo.domain.todo.dto.TodoCreationRequestDto;
 import com.example.todo.domain.todo.dto.TodoCreationResponseDto;
+import com.example.todo.domain.todo.dto.TodoUpdateRequestDto;
+import com.example.todo.domain.todo.dto.TodoUpdateResponseDto;
 import com.example.todo.domain.todo.entity.Todo;
 import com.example.todo.domain.todo.repository.TodoRepository;
 import java.util.List;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class TodoService {
 
     private final TodoRepository todoRepository;
+
 
     @Transactional
     public TodoCreationResponseDto createTodo(TodoCreationRequestDto requestDto) {
@@ -47,6 +50,26 @@ public class TodoService {
                 .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
 
         return new TodoCreationResponseDto(
+                todo.getId(),
+                todo.getDescription(),
+                todo.isCompleted(),
+                todo.getCreatedAt()
+        );
+    }
+
+    @Transactional
+    public  TodoUpdateResponseDto updateTodo(Long id, TodoUpdateRequestDto requestDto) {
+
+        if (requestDto.getDescription() == null || requestDto.getDescription().trim().isEmpty()) {
+            throw new CustomException(ErrorCode.TODO_DESCRIPTION_REQUIRED);
+        }
+
+        Todo todo = todoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
+
+        todo.setDescription(requestDto.getDescription());
+
+        return new TodoUpdateResponseDto(
                 todo.getId(),
                 todo.getDescription(),
                 todo.isCompleted(),


### PR DESCRIPTION
### 설명
이 PR은 사용자가 생성한 할일들 중에서 원하는 할일 1개를 조회하는 기능구현 이며, 예외 발생시 에대한  에러 코드와 메시지 반환하기 위해서 관련된 설정 또한 추가 하였습니다.

### 주요 변경 사항
- **Controller**: API 추가
- **Service**: 수정 메서드, 수정내용 미포함 검증 로직 추가
- **예외 처리**: TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다."),
 TODO_DESCRIPTION_REQUIRED(400, "작성된 내용이 없습니다.")

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 실행시 이전에 작성했던 할일의 내용이 수정되는 것을 확인 하였습니다.