### PR TITLE
Feature/todo 할일 삭제 기능 추가

### DIFF
--- a/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
@@ -11,6 +11,7 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -63,5 +64,14 @@ public class TodoController {
         TodoUpdateResponseDto updatedTodo = todoService.updateTodo(id, todoRequest);
 
         return ResponseEntity.ok().body(CommonResponse.of("할일 수정 성공", updatedTodo));
+    }
+
+    @DeleteMapping("/today/{id}")
+    public ResponseEntity<CommonResponse<TodoUpdateResponseDto>> deleteTodo(
+            @PathVariable Long id) {
+
+        todoService.deleteTodo(id);
+
+        return ResponseEntity.ok().body(CommonResponse.of("할일 삭제 성공", null));
     }
 }

--- a/src/main/java/com/example/todo/domain/todo/service/TodoService.java
+++ b/src/main/java/com/example/todo/domain/todo/service/TodoService.java
@@ -19,7 +19,6 @@ public class TodoService {
 
     private final TodoRepository todoRepository;
 
-
     @Transactional
     public TodoCreationResponseDto createTodo(TodoCreationRequestDto requestDto) {
 
@@ -75,5 +74,15 @@ public class TodoService {
                 todo.isCompleted(),
                 todo.getCreatedAt()
         );
+    }
+
+    @Transactional
+    public void deleteTodo(Long id) {
+
+        Todo todo = todoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
+
+        todoRepository.delete(todo);
+
     }
 }


### PR DESCRIPTION
### 설명
이 PR은 사용자가 생성한 할일들 중에서 원하는 할일 1개를 삭제하는 기능구현 입니다.

### 주요 변경 사항
- **Controller**: API 추가
- **Service**: 수정 메서드, 수정내용 미포함 검증 로직 추가
- **예외 처리**: TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다."),

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 실행시 이전에 작성했던 할일의 내용이 삭제되는 것을 확인 하였습니다.