### PR TITLE
Feature/todo 할일 상태 변경 기능 추가

### DIFF
--- a/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
+++ b/src/main/java/com/example/todo/domain/todo/controller/TodoController.java
@@ -13,6 +13,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -64,6 +65,15 @@ public class TodoController {
         TodoUpdateResponseDto updatedTodo = todoService.updateTodo(id, todoRequest);
 
         return ResponseEntity.ok().body(CommonResponse.of("할일 수정 성공", updatedTodo));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<CommonResponse<TodoUpdateResponseDto>> updateTodoState(
+            @PathVariable Long id) {
+
+        TodoUpdateResponseDto updatedTodo = todoService.updateTodoState(id);
+
+        return ResponseEntity.ok(CommonResponse.of("할일 상태 변경 성공", updatedTodo));
     }
 
     @DeleteMapping("/today/{id}")

--- a/src/main/java/com/example/todo/domain/todo/service/TodoService.java
+++ b/src/main/java/com/example/todo/domain/todo/service/TodoService.java
@@ -81,6 +81,22 @@ public class TodoService {
     }
 
     @Transactional
+    public TodoUpdateResponseDto updateTodoState(Long id) {
+        Todo todo = todoRepository.findById(id)
+                .orElseThrow(() -> new CustomException(ErrorCode.TODO_NOT_FOUND));
+
+        todo.setCompleted(!todo.isCompleted());
+        todoRepository.save(todo);
+
+        return new TodoUpdateResponseDto(
+                todo.getId(),
+                todo.getDescription(),
+                todo.isCompleted(),
+                todo.getCreatedAt()
+        );
+    }
+
+    @Transactional
     public void deleteTodo(Long id) {
 
         Todo todo = todoRepository.findById(id)


### PR DESCRIPTION
### 설명
이 PR은 사용자가 생성한 할일들 중에서 원하는 할일 의 상태를 '완료' 혹은 '미완료' 로 변경 하게 해주는 기능입니다.

### 주요 변경 사항
- **Controller**: API 추가
- **Service**: 할일의 상태인 completed의 값(true, false)을 확인후 반대 값으로 변환하는 로직 추가
- **예외 처리**: TODO_NOT_FOUND(400, "할일 을 찾을 수 없습니다.")

#### 테스트 :
- 포스트맨(Postman)을 사용하여 API 엔드포인트에 대한 통합 테스트를 수행하였습니다.
- 실행시 이전에 작성했던 할일의 상태가 입력될때마다 변경 되는것을 확인 하였습니다.